### PR TITLE
platform notation fix for newer CocoaPods version

### DIFF
--- a/EDQueue.podspec
+++ b/EDQueue.podspec
@@ -6,8 +6,8 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/thisandagain/queue'
   s.authors      = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
   s.source       = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.1' }
-  s.platform     = :ios, '5.0'
-  s.platform     = :osx, '10.8'
+  s.ios.platform = :ios, '5.0'
+  s.osx.platform = :osx, '10.8'
   s.source_files = 'EDQueue'
   s.library      = 'sqlite3.0'
   s.requires_arc = true


### PR DESCRIPTION
s.platform notation fails with CocoaPods version 0.39.0
